### PR TITLE
feat/#16 - add dynamic capability to Add-Update Form

### DIFF
--- a/react/src/App.jsx
+++ b/react/src/App.jsx
@@ -1,13 +1,16 @@
 import './App.css'
 import AddUpdateForm from './components/AddUpdateForm'
 import CustomerList from './components/CustomerList'
+import { CustomerProvider } from './components/hooks/CustomerContext'
 
 function App() {
 
   return (
     <>
-      <CustomerList />
-      <AddUpdateForm />
+      <CustomerProvider>
+        <CustomerList />
+        <AddUpdateForm />
+      </CustomerProvider>
     </>
   )
 }

--- a/react/src/components/AddUpdateForm.jsx
+++ b/react/src/components/AddUpdateForm.jsx
@@ -1,20 +1,28 @@
 import React from "react";
+import { useCustomer } from "./hooks/CustomerContext";
 
 const AddUpdateForm = () => {
+
+  const { customer, emptyCustomer } = useCustomer();
+
+  const setTitle = () => {
+    return customer.id !== emptyCustomer.id ? 'Update' : 'Add'
+  }
+
   return (
     <>
-      <h2 id="add-update-form-title">Add/Update</h2>
+      <h2 id="add-update-form-title">{setTitle()}</h2>
       <div>
         <label htmlFor="name">Name:</label>
-        <input type="text" id="name" placeholder="Customer Name"></input>
+        <input type="text" id="name" placeholder="Customer Name" value={customer.name}></input>
       </div>
       <div>
         <label htmlFor="email">Email:</label>
-        <input type="email" id="email" placeholder="name@company.com"></input>
+        <input type="email" id="email" placeholder="name@company.com" value={customer.email}></input>
       </div>
       <div>
         <label htmlFor="password">Pass:</label>
-        <input type="text" id="password" placeholder="password"></input>
+        <input type="text" id="password" placeholder="password" value={customer.password}></input>
       </div>
       <div>
         <button id="btn-delete">Delete</button>
@@ -25,4 +33,4 @@ const AddUpdateForm = () => {
   )
 }
 
-export default AddUpdateForm;
+export default AddUpdateForm; 

--- a/react/src/components/AddUpdateForm.test.jsx
+++ b/react/src/components/AddUpdateForm.test.jsx
@@ -1,12 +1,35 @@
-import React from 'react';
+import React, { createContext, useContext } from 'react';
 import { render, screen } from '@testing-library/react';
 import AddUpdateForm from './AddUpdateForm';
 import '@testing-library/jest-dom';
+import * as CustomerContext from './hooks/CustomerContext';
+
+jest.mock('./hooks/CustomerContext');
+
+const CUSTOMER = {
+  "id": 0,
+  "name": "Mary Jackson",
+  "email": "maryj@abc.com",
+  "password": "maryj"
+};
+
+const EMPTY_CUSTOMER = {
+  id: -1,
+  name: "",
+  email: "",
+  password: ""
+};
+
 
 describe('Add-Update form', () => {
-  it('Should have all components', () => {
+
+  afterEach(() => {
+    CustomerContext.useCustomer.mockClear();
+  })
+
+  it('Should have all components and in state Add', () => {
     // Given
-    const title = 'Add/Update';
+    const title = 'Add';
     const nameLabel = 'Name:';
     const namePlaceholder = 'Customer Name';
 
@@ -20,7 +43,16 @@ describe('Add-Update form', () => {
     const saveName = 'Save';
     const cancelName = 'Cancel';
 
-    render(<AddUpdateForm />);
+    const contextValues = {
+      customer: EMPTY_CUSTOMER,
+      emptyCustomer: EMPTY_CUSTOMER
+    }
+
+    jest.spyOn(CustomerContext, 'useCustomer').mockImplementationOnce(() => contextValues);
+
+    render(
+      <AddUpdateForm />
+    );
 
     // When
     const titleElement = screen.getByRole('heading', { name: title });
@@ -45,5 +77,35 @@ describe('Add-Update form', () => {
     expect(deleteButton).toBeInTheDocument();
     expect(saveButton).toBeInTheDocument();
     expect(cancelButton).toBeInTheDocument();
+  });
+
+  it("Should fill form when in Update state", async () => {
+    // Given
+    const title = 'Update';
+    const nameValue = CUSTOMER.name;
+    const emailValue = CUSTOMER.email;
+    const passwordValue = CUSTOMER.password;
+    const contextValues = {
+      customer: CUSTOMER,
+      emptyCustomer: EMPTY_CUSTOMER
+    }
+
+    jest.spyOn(CustomerContext, 'useCustomer').mockImplementationOnce(() => contextValues);
+
+    render(
+      <AddUpdateForm />
+    );
+
+    // When
+    const titleElement = await screen.findByRole('heading', { name: title });
+    const nameInput = await screen.findByDisplayValue(nameValue);
+    const emailInput = await screen.findByDisplayValue(emailValue);
+    const passwordInput = await screen.findByDisplayValue(passwordValue);
+
+    // Then
+    expect(titleElement).toBeInTheDocument();
+    expect(nameInput).toBeInTheDocument();
+    expect(emailInput).toBeInTheDocument();
+    expect(passwordInput).toBeInTheDocument();
   })
 });

--- a/react/src/components/CustomerList.test.jsx
+++ b/react/src/components/CustomerList.test.jsx
@@ -3,6 +3,7 @@ import { render, screen } from '@testing-library/react';
 import CustomerList from './CustomerList';
 import '@testing-library/jest-dom';
 import * as restdb from '../rest/restdb';
+import { CustomerProvider } from './hooks/CustomerContext';
 
 const returnData = [
   {
@@ -25,7 +26,11 @@ describe("Customer List", () => {
   it("Customer List title should be visible", async () => {
     // Given
     const HEADING_TITLE = 'Customer List';
-    render(<CustomerList />);
+    render(
+      <CustomerProvider>
+        <CustomerList />
+      </CustomerProvider>
+    );
 
     // When
     const headingElement = await screen.findByRole('heading', { name: new RegExp(HEADING_TITLE) });
@@ -39,7 +44,11 @@ describe("Customer List", () => {
     const nameColumn = 'Name';
     const emailColumn = 'Email';
     const passwordColumn = 'Pass';
-    const { findByRole } = render(<CustomerList />);
+    const { findByRole } = render(
+      <CustomerProvider>
+        <CustomerList />
+      </CustomerProvider>
+    );
 
     // When
     const nameElement = await findByRole('columnheader', { name: nameColumn });
@@ -54,7 +63,11 @@ describe("Customer List", () => {
 
   it('Should contain returned data', async () => {
     // Given
-    const { findByRole } = render(<CustomerList />);
+    const { findByRole } = render(
+      <CustomerProvider>
+        <CustomerList />
+      </CustomerProvider>
+    );
 
     // When
     const name = await findByRole('cell', { name: returnData[0].name });

--- a/react/src/components/CustomerTable.jsx
+++ b/react/src/components/CustomerTable.jsx
@@ -1,33 +1,27 @@
 import React, { useEffect, useState } from 'react';
+import { useCustomer } from './hooks/CustomerContext';
 import { getAll } from '../rest/restdb';
 import './styles/CustomerTable.css';
-
-const EMPTY_CUSTOMER = {
-  id: -1,
-  name: "",
-  email: "",
-  password: ""
-};
 
 const CustomerTable = () => {
 
   const [customerData, setCustomerData] = useState([]);
-  const [selectedCustomer, setSelectedCustomer] = useState(EMPTY_CUSTOMER);
+  const { customer, emptyCustomer, setCustomer } = useCustomer();
 
   useEffect(() => {
     getAll().then(response => setCustomerData(response));
   }, []);
 
-  const onRowClick = (customer) => {
-    if (selectedCustomer.id === customer.id) {
-      setSelectedCustomer(EMPTY_CUSTOMER);
+  const onRowClick = (selectedCustomer) => {
+    if (customer.id === selectedCustomer.id) {
+      setCustomer(emptyCustomer);
       return;
     }
-    setSelectedCustomer(customer);
+    setCustomer(selectedCustomer);
   }
 
   const selectedClass = (customerId) => {
-    if (selectedCustomer.id !== customerId) {
+    if (customer.id !== customerId) {
       return undefined;
     }
     return "selected"

--- a/react/src/components/CustomerTable.test.jsx
+++ b/react/src/components/CustomerTable.test.jsx
@@ -3,6 +3,7 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import CustomerTable from './CustomerTable';
 import '@testing-library/jest-dom';
 import * as restdb from '../rest/restdb';
+import { CustomerProvider, useCustomer } from './hooks/CustomerContext';
 
 const returnData = [
   {
@@ -11,6 +12,13 @@ const returnData = [
     "email": "maryj@abc.com",
     "password": "maryj"
   }];
+
+const EMPTY_CUSTOMER = {
+  id: -1,
+  name: "",
+  email: "",
+  password: ""
+};
 
 describe('Customer Table', () => {
 
@@ -27,7 +35,11 @@ describe('Customer Table', () => {
     const nameColumn = 'Name';
     const emailColumn = 'Email';
     const passwordColumn = 'Pass';
-    const { findByRole } = render(<CustomerTable />);
+    const { findByRole } = render(
+      <CustomerProvider>
+        <CustomerTable />
+      </CustomerProvider>
+    );
 
     // When
     const nameElement = await findByRole('columnheader', { name: nameColumn });
@@ -42,7 +54,11 @@ describe('Customer Table', () => {
 
   it('Should contain returned data', async () => {
     // Given
-    const { findByRole } = render(<CustomerTable />);
+    const { findByRole } = render(
+      <CustomerProvider>
+        <CustomerTable />
+      </CustomerProvider>
+    );
 
     // When
     const name = await findByRole('cell', { name: returnData[0].name });
@@ -58,7 +74,11 @@ describe('Customer Table', () => {
 
   it('Should fire event and select when clicking on table', async () => {
     // Given
-    const { findByRole } = render(<CustomerTable />);
+    const { findByRole } = render(
+      <CustomerProvider>
+        <CustomerTable />
+      </CustomerProvider>
+    );
     const name = await findByRole('cell', { name: returnData[0].name });
     const customerRow = name.closest('tr');
 
@@ -73,7 +93,11 @@ describe('Customer Table', () => {
 
   it('Should deselect a customer when clicked twice', async () => {
     // Given
-    const { findByRole } = render(<CustomerTable />);
+    const { findByRole } = render(
+      <CustomerProvider>
+        <CustomerTable />
+      </CustomerProvider>
+    );
     const name = await findByRole('cell', { name: returnData[0].name });
     const customerRow = name.closest('tr');
 

--- a/react/src/components/hooks/CustomerContext.jsx
+++ b/react/src/components/hooks/CustomerContext.jsx
@@ -1,0 +1,23 @@
+import React, { createContext, useContext, useState } from 'react';
+
+const EMPTY_CUSTOMER = {
+  id: -1,
+  name: "",
+  email: "",
+  password: ""
+};
+
+const CustomerContext = createContext(EMPTY_CUSTOMER);
+
+export const CustomerProvider = ({ children }) => {
+  const emptyCustomer = EMPTY_CUSTOMER;
+  const [customer, setCustomer] = useState(EMPTY_CUSTOMER);
+
+  return (
+    <CustomerContext.Provider value={{ customer, emptyCustomer, setCustomer }}>
+      {children}
+    </CustomerContext.Provider>
+  )
+}
+
+export const useCustomer = () => useContext(CustomerContext);

--- a/react/src/components/hooks/CustomerContext.test.jsx
+++ b/react/src/components/hooks/CustomerContext.test.jsx
@@ -1,0 +1,97 @@
+import React, { useEffect } from 'react';
+import { render, screen } from '@testing-library/react';
+import { CustomerProvider, useCustomer } from './CustomerContext';
+import '@testing-library/jest-dom';
+
+const EMPTY_CUSTOMER = {
+  id: -1,
+  name: "",
+  email: "",
+  password: ""
+};
+
+const CUSTOMER = {
+  "id": 0,
+  "name": "Mary Jackson",
+  "email": "maryj@abc.com",
+  "password": "maryj"
+};
+
+const TestingInitialCustomer = () => {
+  const { customer } = useCustomer();
+  return (
+    <div>
+      {JSON.stringify(customer)}
+    </div>
+  )
+};
+
+const TestingEmptyCustomer = () => {
+  const { emptyCustomer } = useCustomer();
+  return (
+    <div>
+      {JSON.stringify(emptyCustomer)}
+    </div>
+  )
+};
+
+const TestingSetCustomer = () => {
+  const { customer, setCustomer } = useCustomer();
+
+  useEffect(() => {
+    setCustomer(CUSTOMER);
+  })
+
+  return (
+    <div>
+      {JSON.stringify(customer)}
+    </div>
+  )
+};
+
+describe("Customer Context Provider", () => {
+  it("Initial selected customer should by empty", () => {
+    // Given
+    render(
+      <CustomerProvider>
+        <TestingInitialCustomer />
+      </CustomerProvider>
+    )
+
+    // When
+    const customerElement = screen.getByText(JSON.stringify(EMPTY_CUSTOMER));
+
+    // Then
+    expect(customerElement).toBeInTheDocument();
+  });
+
+  it("Empty customer should by empty", () => {
+    // Given
+    render(
+      <CustomerProvider>
+        <TestingEmptyCustomer />
+      </CustomerProvider>
+    )
+
+    // When
+    const customerElement = screen.getByText(JSON.stringify(EMPTY_CUSTOMER));
+
+    // Then
+    expect(customerElement).toBeInTheDocument();
+  });
+
+  it("Customer should by set properly", async () => {
+    // Given
+    render(
+      <CustomerProvider>
+        <TestingSetCustomer />
+      </CustomerProvider>
+    )
+
+    // When
+    const customerElement = await screen.findByText(JSON.stringify(CUSTOMER));
+
+    // Then
+    expect(customerElement).toBeInTheDocument();
+  })
+});


### PR DESCRIPTION
Added dynamic capability to add update form. After clicking a customer the form will switch to Update state and display current customer data.

![image](https://github.com/user-attachments/assets/d33bfe8d-5596-4d7c-bfec-6dc4994ffa07)

Tests are created to cover this and all tests are passing, coverage is 100%.