### PR TITLE
feat/#34 - add handling Cancel button and tests

### DIFF
--- a/react/src/components/AddUpdateForm.jsx
+++ b/react/src/components/AddUpdateForm.jsx
@@ -34,10 +34,14 @@ const AddUpdateForm = (props) => {
 
       addCustomer(newCustomer);
       setCustomerData(emptyCustomer);
+      return;
     }
     await updateCustomer(customerData);
     setCustomer(emptyCustomer);
-    setCustomerData(emptyCustomer);
+  }
+
+  const onCancel = () => {
+    setCustomer(emptyCustomer);
   }
 
   useEffect(() => {
@@ -68,7 +72,7 @@ const AddUpdateForm = (props) => {
       <div>
         <button id="btn-delete" onClick={onDelete}>Delete</button>
         <button id="btn-save" onClick={onSave}>Save</button>
-        <button id="btn-cancel">Cancel</button>
+        <button id="btn-cancel" onClick={onCancel}>Cancel</button>
       </div>
     </>
   )

--- a/react/src/components/AddUpdateForm.test.jsx
+++ b/react/src/components/AddUpdateForm.test.jsx
@@ -249,7 +249,7 @@ describe('Add-Update form', () => {
     const saveButton = screen.getByRole('button', { name: saveName });
 
     // When
-    await fireEvent.click(saveButton);
+    fireEvent.click(saveButton);
     const emptyName = await screen.findByPlaceholderText(namePlaceholder);
     const emptyEmail = await screen.findByPlaceholderText(emailPlaceholder);
     const emptyPassword = await screen.findByPlaceholderText(passwordPlaceholder);
@@ -257,6 +257,36 @@ describe('Add-Update form', () => {
     // Then
     expect(crudOperations.addCustomer).not.toHaveBeenCalled();
     expect(crudOperations.updateCustomer).toHaveBeenCalledTimes(1);
+    expect(emptyName).toBeInTheDocument();
+    expect(emptyEmail).toBeInTheDocument();
+    expect(emptyPassword).toBeInTheDocument();
+  });
+
+  it("Should deselect customer when Cancel is clicked", async () => {
+    // Given
+    const namePlaceholder = 'Customer Name';
+    const emailPlaceholder = 'name@company.com';
+    const passwordPlaceholder = 'password';
+    const contextValues = {
+      customer: CUSTOMER,
+      emptyCustomer: EMPTY_CUSTOMER,
+      setCustomer: jest.fn()
+    }
+    jest.spyOn(CustomerContext, 'useCustomer').mockImplementationOnce(() => contextValues);
+
+    render(
+      <AddUpdateForm crudOperations={crudOperations} />
+    );
+    const cancelName = 'Cancel';
+    const cancelButton = screen.getByRole('button', { name: cancelName });
+
+    // When
+    fireEvent.click(cancelButton);
+    const emptyName = await screen.findByPlaceholderText(namePlaceholder);
+    const emptyEmail = await screen.findByPlaceholderText(emailPlaceholder);
+    const emptyPassword = await screen.findByPlaceholderText(passwordPlaceholder);
+
+    // Then
     expect(emptyName).toBeInTheDocument();
     expect(emptyEmail).toBeInTheDocument();
     expect(emptyPassword).toBeInTheDocument();


### PR DESCRIPTION
Added handling Cancel button. Cancel button deselects currently selected record. When no record is selected, nothing happens.

Added unit test to cover new functionality, coverage is 100%.